### PR TITLE
Update document.rs remove index from path

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -64,7 +64,7 @@ impl Document {
             .enumerate()
             .map(|(idx, chunk)| Document {
                 ident: format!("{}@{}", self.ident, idx),
-                path: format!("{}@{}", self.path, idx),
+                path: format!("{}", self.path),
                 data: Some(chunk.iter().collect::<String>()),
             })
             .collect());


### PR DESCRIPTION
By giving @0 (idx) for the paths when we call doc.get_data it is not able to find the path@0 

So updating this fixed the following issue

https://github.com/evilsocket/nerve/issues/14